### PR TITLE
Fix review modal not clearing previously entered data.

### DIFF
--- a/src/app/modules/module-reviews/module-review-new/module-review-edit.component.ts
+++ b/src/app/modules/module-reviews/module-review-new/module-review-edit.component.ts
@@ -27,7 +27,7 @@ export class ModuleReviewEditComponent extends ModuleReviewBaseComponent impleme
 
         this.storeSubscription(
             this.reviewsService.reviewEditModalDisplayed.subscribe(value => {
-                this.displayModal = value;
+                this.setModalDisplayed(value);
             })
         );
 

--- a/src/app/modules/module-reviews/module-review-new/module-review-new.component.ts
+++ b/src/app/modules/module-reviews/module-review-new/module-review-new.component.ts
@@ -27,7 +27,7 @@ export class ModuleReviewNewComponent extends ModuleReviewBaseComponent implemen
 
         this.storeSubscription(
             this.reviewsService.reviewNewModalDisplayed.subscribe(value => {
-                this.displayModal = value;
+                this.setModalDisplayed(value);
             })
         );
 

--- a/src/app/reviews/review-new.component.ts
+++ b/src/app/reviews/review-new.component.ts
@@ -19,6 +19,10 @@ export abstract class ReviewNewComponent extends SubscriptionHandler {
 
     abstract onSubmit();
 
+    setModalDisplayed(value) {
+        value ? this.displayModal = true : this.closeModal();
+    }
+
     closeModal() {
         this.displayModal = false;
         this.reviewForm.reset();


### PR DESCRIPTION
When leaving a review, previously entered data remained filled in once the modal was opened again.